### PR TITLE
Bump node from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: true
     default: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node12 is now deprecated in GitHub Actions.
While Node12 will work at this time, it is recommended that Node16 be used in the future.

For more information, see the following URL
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12